### PR TITLE
fix: docker volume mount permission issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: semapps/jena-fuseki-webacl
     container_name: fuseki
     volumes:
-      - ./data/fuseki:/fuseki
+      - ./data/fuseki:/fuseki:z
     ports:
       - "3030:3030"
     expose:
@@ -16,7 +16,7 @@ services:
     image: semapps/jena-fuseki-webacl
     container_name: fuseki_test
     volumes:
-      - ./data/fuseki_test:/fuseki
+      - ./data/fuseki_test:/fuseki:z
     ports:
       - "3040:3030"
     expose:


### PR DESCRIPTION
I encountered a permission issue trying to launch fuseki with my fedora machine. The container did not have the rights to access the data directory.
Exposing the volume without the `z` parameter seems to break things in SELinux. See: https://stackoverflow.com/questions/24288616/permission-denied-on-accessing-host-directory-in-docker