### PR TITLE
Make prettier run automatically before commit

### DIFF
--- a/.git-hooks/post-commit
+++ b/.git-hooks/post-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+git update-index -g

--- a/.git-hooks/post-commit
+++ b/.git-hooks/post-commit
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 git update-index -g

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-if [ $SKIP_PRECOMMIT_PRETTIER ]; then
+if [ "$SKIP_PRECOMMIT_PRETTIER" = true ] || [ "$SKIP_PRECOMMIT_PRETTIER" = 1 ] ; then
     echo "=== Skipping pre-commit prettier run ==="
     exit 0
 fi

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+
+if [[ $SKIP_PRECOMMIT_PRETTIER ]]; then
+    echo "=== Skipping pre-commit prettier run ==="
+    exit 0
+fi
+
+
+echo "=== Running pre-commit prettier ==="
+
+# Select staged files.
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+[ -z "$FILES" ] && echo "=== Nothing to do ===" && exit 0
+
+echo "prettifiying.."
+# Run prettier on all staged files.
+echo "$FILES" | xargs npx prettier --write --ignore-unknown
+
+if [[ $? != 0 ]]; then
+    echo "Something went wrong running prettier. Have you run \`npm install\` yet?
+You can skip prettier on commit by setting \$SKIP_PRECOMMIT_PRETTIER"
+    exit 1
+fi
+
+# Add back the modified/prettified files to staging
+xargs git add "$FILES"
+
+
+echo "=== Prettier done ==="
+
+exit 0

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 
-if [[ $SKIP_PRECOMMIT_PRETTIER ]]; then
+if [ $SKIP_PRECOMMIT_PRETTIER ]; then
     echo "=== Skipping pre-commit prettier run ==="
     exit 0
 fi
@@ -17,7 +17,7 @@ echo "prettifiying.."
 # Run prettier on all staged files.
 echo "$FILES" | xargs npx prettier --write --ignore-unknown
 
-if [[ $? != 0 ]]; then
+if [ $? != 0 ]; then
     echo "Something went wrong running prettier. Have you run \`npm install\` yet?
 You can skip prettier on commit by setting \$SKIP_PRECOMMIT_PRETTIER"
     exit 1

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bootstrap": "lerna bootstrap",
     "version": "lerna version --force-publish='*' --exact",
     "publish": "lerna publish from-package --dist-tag latest",
-    "prettier": "prettier --single-quote --print-width 120 --write --ignore-path .gitignore '**/*.js'",
+    "prettier": "prettier --write '**/*.js'",
     "link-all": "lerna exec --parallel --scope @activitypods/** -- yarn link",
     "unlink-all": "lerna exec --parallel --scope @activitypods/** -- yarn unlink",
     "link-semapps-packages": "yarn link @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/sync @semapps/notifications @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "link-all": "lerna exec --parallel --scope @activitypods/** -- yarn link",
     "unlink-all": "lerna exec --parallel --scope @activitypods/** -- yarn unlink",
     "link-semapps-packages": "yarn link @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/sync @semapps/notifications @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid",
-    "unlink-semapps-packages": "yarn unlink @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/sync @semapps/notifications @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid"
+    "unlink-semapps-packages": "yarn unlink @semapps/activitypub @semapps/auth @semapps/backup @semapps/core @semapps/importer @semapps/inference @semapps/jsonld @semapps/ldp @semapps/middlewares @semapps/mime-types @semapps/sync @semapps/notifications @semapps/pod @semapps/signature @semapps/sparql-endpoint @semapps/triplestore @semapps/webacl @semapps/webfinger @semapps/webhooks @semapps/webid",
+    "preinstall": "git config core.hooksPath .git-hooks"
   },
   "devDependencies": {
     "lerna": "^4.0.0",


### PR DESCRIPTION
- [x] create a `.prettierrc.json` file where the prettier config now resides.
- [x] Add a pre-commit hook script to the respository. The `.git-hooks` directory is set up using npm's `preinstall` script.
        You might have to re-install or run `git config core.hooksPath .git-hooks` manually in existing repositories.

This way, the prettier is run over all staged files. The prettified files are committed.