### PR TITLE
Fix link to github repo

### DIFF
--- a/website/src/components/widgets/Developers.astro
+++ b/website/src/components/widgets/Developers.astro
@@ -21,7 +21,7 @@ import { Icon } from 'astro-icon';
 							<div class="w-full">
 								<a
 									class="btn btn-primary mb-4 sm:mb-0"
-									href="https://github.com/onwidget/astrowind"
+									href="https://github.com/assemblee-virtuelle/activitypods"
 									target="_blank"
 									rel="noopener"
 								>


### PR DESCRIPTION
Add link to the activitypods github repository instead of the existing one (possibly the default of the template used for the website?)