### PR TITLE
Chore/refactor (BREAKING) await create complete

### DIFF
--- a/packages/announcer/service.js
+++ b/packages/announcer/service.js
@@ -33,8 +33,8 @@ module.exports = {
     async giveRightsAfterCreate(ctx) {
       const { resourceUri } = ctx.params;
 
-      const object = await ctx.call('activitypub.object.awaitCreateComplete', {
-        objectUri: resourceUri,
+      const object = await ctx.call('ldp.resource.awaitCreateComplete', {
+        resourceUri,
         predicates: ['dc:creator', 'dc:modified', 'dc:created', 'apods:announces', 'apods:announcers']
       });
 

--- a/packages/events/services/event.js
+++ b/packages/events/services/event.js
@@ -21,8 +21,8 @@ module.exports = {
   hooks: {
     after: {
       async create(ctx, res) {
-        res.newData = await ctx.call('activitypub.object.awaitCreateComplete', {
-          objectUri: res.resourceUri,
+        res.newData = await ctx.call('ldp.resource.awaitCreateComplete', {
+          resourceUri: res.resourceUri,
           predicates: [
             'dc:creator',
             'dc:modified',

--- a/packages/events/services/status.js
+++ b/packages/events/services/status.js
@@ -19,8 +19,8 @@ module.exports = {
       const { eventUri, newStatus } = ctx.params;
 
       // Ensure event is complete (we may have concurrency bugs otherwise)
-      const event = await ctx.call('activitypub.object.awaitCreateComplete', {
-        objectUri: eventUri,
+      const event = await ctx.call('ldp.resource.awaitCreateComplete', {
+        resourceUri: eventUri,
         predicates: [
           'dc:creator',
           'dc:modified',


### PR DESCRIPTION
Depends on https://github.com/assemblee-virtuelle/semapps/pull/1164

The SemApps PR is a **breaking change** since a service action is moved. Here, the calls are adjusted to the new action name.