### PR TITLE
App uninstall

### DIFF
--- a/app-boilerplate/backend/services/app.service.js
+++ b/app-boilerplate/backend/services/app.service.js
@@ -1,13 +1,13 @@
 const { AppService } = require('@activitypods/app');
 const { AS_PREFIX } = require('@semapps/activitypub');
-const CONFIG = require('../config/config');
 
 module.exports = {
   mixins: [AppService],
   settings: {
-    baseUrl: CONFIG.HOME_URL,
-    name: 'Example App',
-    description: 'An ActivityPods-compatible app',
+    app: {
+      name: 'Example App',
+      description: 'An ActivityPods-compatible app'
+    },
     accessNeeds: {
       required: [
         {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,8 +5,12 @@
   "license": "Apache-2.0",
   "author": "Virtual Assembly",
   "dependencies": {
+    "@activitypods/core": "1.1.0",
+    "@rdfjs/data-model": "^1.3.4",
     "@semapps/activitypub": "0.6.0-alpha.0",
-    "@semapps/ldp": "0.6.0-alpha.0"
+    "@semapps/ldp": "0.6.0-alpha.0",
+    "@semapps/mime-types": "0.6.0-alpha.0",
+    "url-join": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/app/service.js
+++ b/packages/app/service.js
@@ -1,23 +1,20 @@
-const urlJoin = require('url-join');
-const { interopContext } = require('@activitypods/core');
-const { ACTOR_TYPES } = require('@semapps/activitypub');
-const { MIME_TYPES } = require('@semapps/mime-types');
-const { triple, namedNode } = require('@rdfjs/data-model');
-
 const AccessNeedsService = require('./services/access-needs');
 const AccessNeedsGroupsService = require('./services/access-needs-groups');
 const ActorsService = require('./services/actors');
+const AppRegistrationsService = require('./services/app-registrations');
+const AccessGrantsService = require('./services/access-grants');
+const DataGrantsService = require('./services/data-grants');
 const RegistrationService = require('./services/registration');
-
-const INTEROP_PREFIX = 'http://www.w3.org/ns/solid/interop#';
 
 module.exports = {
   name: 'app',
   settings: {
-    name: null,
-    description: null,
-    author: null,
-    thumbnail: null,
+    app: {
+      name: null,
+      description: null,
+      author: null,
+      thumbnail: null
+    },
     accessNeeds: {
       required: [],
       optional: []
@@ -31,123 +28,27 @@ module.exports = {
     'ldp.registry'
   ],
   created() {
-    this.broker.createService(AccessNeedsService);
-    this.broker.createService(AccessNeedsGroupsService);
-    this.broker.createService(ActorsService);
+    this.broker.createService(ActorsService, {
+      settings: {
+        app: this.settings.app
+      }
+    });
+
     this.broker.createService(RegistrationService);
+
+    this.broker.createService(AccessNeedsService);
+    this.broker.createService(AccessNeedsGroupsService, {
+      settings: {
+        accessNeeds: this.settings.accessNeeds
+      }
+    });
+
+    this.broker.createService(AppRegistrationsService);
+    this.broker.createService(DataGrantsService);
+    this.broker.createService(AccessGrantsService);
   },
   async started() {
-    await this.createActor();
-  },
-  methods: {
-    async createActor() {
-      // Ensure LDP sub-services have been started
-      await this.broker.waitForServices(['ldp.container', 'ldp.resource']);
-
-      const actorsContainerUri = await this.broker.call('actors.getContainerUri');
-      const actorUri = urlJoin(actorsContainerUri, 'app');
-
-      const actorExist = await this.broker.call('ldp.resource.exist', {
-        resourceUri: actorUri
-      });
-
-      if (!actorExist) {
-        this.logger.info(`Actor ${actorUri} does not exist yet, creating it...`);
-
-        const account = await this.broker.call(
-          'auth.account.create',
-          {
-            username: 'app',
-            webId: actorUri
-          },
-          { meta: { isSystemCall: true } }
-        );
-
-        try {
-          await this.broker.call('actors.post', {
-            slug: 'app',
-            resource: {
-              '@context': ['https://www.w3.org/ns/activitystreams', interopContext],
-              type: [ACTOR_TYPES.APPLICATION, 'interop:Application'],
-              preferredUsername: 'app',
-              name: this.settings.name,
-              'interop:applicationName': this.settings.name,
-              'interop:applicationDescription': this.settings.description,
-              'interop:applicationAuthor': this.settings.author,
-              'interop:applicationThumbnail': this.settings.thumbnail
-            },
-            contentType: MIME_TYPES.JSON,
-            webId: 'system'
-          });
-        } catch (e) {
-          // Delete account if resource creation failed, or it may cause problems when retrying
-          await this.broker.call('auth.account.remove', { id: account['@id'] });
-          throw e;
-        }
-
-        this.actor = await this.broker.call('activitypub.actor.awaitCreateComplete', { actorUri });
-
-        await this.createAccessNeeds();
-      } else {
-        this.actor = await this.broker.call('activitypub.actor.awaitCreateComplete', { actorUri });
-      }
-    },
-    async createAccessNeeds() {
-      let accessNeedGroupsUris = [];
-
-      for (let [necessity, accessNeeds] of Object.entries(this.settings.accessNeeds)) {
-        let accessNeedsUris = [],
-          specialRights = [];
-
-        if (accessNeeds.length > 0) {
-          for (const accessNeed of accessNeeds) {
-            if (typeof accessNeed === 'string') {
-              // If a string is provided, we have a special access need (e.g. apods:ReadInbox)
-              specialRights.push(accessNeed);
-            } else {
-              accessNeedsUris.push(
-                await this.broker.call('access-needs.post', {
-                  resource: {
-                    '@context': interopContext,
-                    '@type': 'interop:AccessNeed',
-                    'interop:accessNecessity':
-                      necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
-                    'interop:accessMode': accessNeed.accessMode,
-                    'apods:registeredClass': accessNeed.registeredClass
-                  },
-                  contentType: MIME_TYPES.JSON,
-                  webId: 'system'
-                })
-              );
-            }
-          }
-
-          accessNeedGroupsUris.push(
-            await this.broker.call('access-needs-groups.post', {
-              resource: {
-                '@context': interopContext,
-                '@type': 'interop:AccessNeedGroup',
-                'interop:accessNecessity':
-                  necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
-                'interop:accessScenario': 'interop:PersonalAccess',
-                'interop:authenticatedAs': 'interop:SocialAgent',
-                'interop:hasAccessNeed': accessNeedsUris,
-                'apods:hasSpecialRights': specialRights
-              },
-              contentType: MIME_TYPES.JSON,
-              webId: 'system'
-            })
-          );
-        }
-      }
-
-      await this.broker.call('ldp.resource.patch', {
-        resourceUri: this.actor.id,
-        triplesToAdd: accessNeedGroupsUris.map(uri =>
-          triple(namedNode(this.actor.id), namedNode(INTEROP_PREFIX + 'hasAccessNeedGroup'), namedNode(uri))
-        ),
-        webId: 'system'
-      });
-    }
+    await this.broker.waitForServices(['actors'], 10000);
+    await this.broker.call('actors.createApp');
   }
 };

--- a/packages/app/services/access-grants.js
+++ b/packages/app/services/access-grants.js
@@ -1,11 +1,11 @@
 const { ControlledContainerMixin } = require('@semapps/ldp');
 
 module.exports = {
-  name: 'access-needs',
+  name: 'access-grants',
   mixins: [ControlledContainerMixin],
   settings: {
-    path: '/access-needs',
-    acceptedTypes: ['interop:AccessNeed'],
-    readOnly: true
+    path: '/access-grants',
+    acceptedTypes: ['interop:AccessGrant'],
+    newResourcesPermissions: {}
   }
 };

--- a/packages/app/services/access-needs-groups.js
+++ b/packages/app/services/access-needs-groups.js
@@ -1,11 +1,73 @@
 const { ControlledContainerMixin } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { interopContext } = require('@activitypods/core');
 
 module.exports = {
   name: 'access-needs-groups',
   mixins: [ControlledContainerMixin],
   settings: {
+    accessNeeds: {
+      required: [],
+      optional: []
+    },
+    // ControlledContainerMixin settings
     path: '/access-needs-groups',
     acceptedTypes: ['interop:AccessNeedGroup'],
     readOnly: true
+  },
+  dependencies: ['actors'],
+  actions: {
+    async initialize(ctx) {
+      for (const [necessity, accessNeeds] of Object.entries(this.settings.accessNeeds)) {
+        let accessNeedsUris = [],
+          specialRights = [];
+
+        if (accessNeeds.length > 0) {
+          for (const accessNeed of accessNeeds) {
+            if (typeof accessNeed === 'string') {
+              // If a string is provided, we have a special access need (e.g. apods:ReadInbox)
+              specialRights.push(accessNeed);
+            } else {
+              accessNeedsUris.push(
+                await ctx.call('access-needs.post', {
+                  resource: {
+                    '@context': interopContext,
+                    '@type': 'interop:AccessNeed',
+                    'interop:accessNecessity':
+                      necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
+                    'interop:accessMode': accessNeed.accessMode,
+                    'apods:registeredClass': accessNeed.registeredClass
+                  },
+                  contentType: MIME_TYPES.JSON,
+                  webId: 'system'
+                })
+              );
+            }
+          }
+
+          const accessNeedGroupUri = await this.actions.post(
+            {
+              resource: {
+                '@context': interopContext,
+                '@type': 'interop:AccessNeedGroup',
+                'interop:accessNecessity':
+                  necessity === 'required' ? 'interop:AccessRequired' : 'interop:AccessOptional',
+                'interop:accessScenario': 'interop:PersonalAccess',
+                'interop:authenticatedAs': 'interop:SocialAgent',
+                'interop:hasAccessNeed': accessNeedsUris,
+                'apods:hasSpecialRights': specialRights
+              },
+              contentType: MIME_TYPES.JSON,
+              webId: 'system'
+            },
+            {
+              parentCtx: ctx
+            }
+          );
+
+          await ctx.call('actors.attachAccessNeedGroup', { accessNeedGroupUri });
+        }
+      }
+    }
   }
 };

--- a/packages/app/services/actors.js
+++ b/packages/app/services/actors.js
@@ -1,12 +1,105 @@
+const urlJoin = require('url-join');
 const { ControlledContainerMixin } = require('@semapps/ldp');
 const { ACTOR_TYPES } = require('@semapps/activitypub');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { triple, namedNode } = require('@rdfjs/data-model');
+const { interopContext } = require('@activitypods/core');
+
+const INTEROP_PREFIX = 'http://www.w3.org/ns/solid/interop#';
 
 module.exports = {
   name: 'actors',
   mixins: [ControlledContainerMixin],
   settings: {
+    app: {
+      name: null,
+      description: null,
+      author: null,
+      thumbnail: null
+    },
+    // ControlledContainerMixin settings
     path: '/actors',
     acceptedTypes: [ACTOR_TYPES.APPLICATION, 'interop:Application'],
     readOnly: true
+  },
+  dependencies: [
+    'activitypub',
+    'activitypub.follow', // Ensure the /followers and /following collection are registered
+    'auth.account',
+    'ldp.container',
+    'ldp.registry'
+  ],
+  actions: {
+    async createApp(ctx) {
+      // Ensure LDP sub-services have been started
+      await this.broker.waitForServices(['ldp.container', 'ldp.resource']);
+
+      const actorsContainerUri = await this.actions.getContainerUri({}, { parentCtx: ctx });
+      const actorUri = urlJoin(actorsContainerUri, 'app');
+
+      const actorExist = await ctx.call('ldp.resource.exist', {
+        resourceUri: actorUri
+      });
+
+      if (!actorExist) {
+        this.logger.info(`Actor ${actorUri} does not exist yet, creating it...`);
+
+        const account = await ctx.call(
+          'auth.account.create',
+          {
+            username: 'app',
+            webId: actorUri
+          },
+          { meta: { isSystemCall: true } }
+        );
+
+        try {
+          await this.actions.post(
+            {
+              slug: 'app',
+              resource: {
+                '@context': ['https://www.w3.org/ns/activitystreams', interopContext],
+                type: [ACTOR_TYPES.APPLICATION, 'interop:Application'],
+                preferredUsername: 'app',
+                name: this.settings.app.name,
+                'interop:applicationName': this.settings.app.name,
+                'interop:applicationDescription': this.settings.app.description,
+                'interop:applicationAuthor': this.settings.app.author,
+                'interop:applicationThumbnail': this.settings.app.thumbnail
+              },
+              contentType: MIME_TYPES.JSON,
+              webId: 'system'
+            },
+            { parentCtx: ctx }
+          );
+        } catch (e) {
+          // Delete account if resource creation failed, or it may cause problems when retrying
+          await ctx.call('auth.account.remove', { id: account['@id'] });
+          throw e;
+        }
+
+        this.appActor = await ctx.call('activitypub.actor.awaitCreateComplete', { actorUri });
+
+        await ctx.call('access-needs-groups.initialize');
+      } else {
+        this.appActor = await ctx.call('activitypub.actor.awaitCreateComplete', { actorUri });
+      }
+
+      return this.appActor;
+    },
+    async attachAccessNeedGroup(ctx) {
+      const { accessNeedGroupUri } = ctx.params;
+      await ctx.call('ldp.resource.patch', {
+        resourceUri: this.appActor.id,
+        triplesToAdd: [
+          triple(
+            namedNode(this.appActor.id),
+            namedNode(INTEROP_PREFIX + 'hasAccessNeedGroup'),
+            namedNode(accessNeedGroupUri)
+          )
+        ],
+        webId: 'system'
+      });
+    }
   }
 };

--- a/packages/app/services/app-registrations.js
+++ b/packages/app/services/app-registrations.js
@@ -1,4 +1,6 @@
-const { ControlledContainerMixin } = require('@semapps/ldp');
+const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { interopContext } = require('@activitypods/core');
 
 module.exports = {
   name: 'app-registrations',
@@ -7,5 +9,60 @@ module.exports = {
     path: '/app-registrations',
     acceptedTypes: ['interop:ApplicationRegistration'],
     newResourcesPermissions: {}
+  },
+  actions: {
+    async getForActor(ctx) {
+      const { actorUri } = ctx.params;
+
+      let filteredContainer = await this.actions.list(
+        {
+          filters: {
+            'http://www.w3.org/ns/solid/interop#registeredBy': actorUri
+          },
+          jsonContext: interopContext,
+          accept: MIME_TYPES.JSON
+        },
+        { parentCtx: ctx }
+      );
+
+      return filteredContainer['ldp:contains']?.[0];
+    }
+  },
+  hooks: {
+    before: {
+      async delete(ctx) {
+        const { resourceUri, webId } = ctx.params;
+
+        const appRegistration = await ctx.call('ldp.resource.get', {
+          resourceUri,
+          jsonContext: interopContext,
+          accept: MIME_TYPES.JSON,
+          webId
+        });
+
+        // DELETE ALL RELATED GRANTS
+
+        for (const accessGrantUri of arrayOf(appRegistration['interop:hasAccessGrant'])) {
+          const accessGrant = await ctx.call('ldp.resource.get', {
+            resourceUri: accessGrantUri,
+            jsonContext: interopContext,
+            accept: MIME_TYPES.JSON,
+            webId
+          });
+
+          for (const dataGrantUri of arrayOf(accessGrant['interop:hasDataGrant'])) {
+            await ctx.call('ldp.resource.delete', {
+              resourceUri: dataGrantUri,
+              webId
+            });
+          }
+
+          await ctx.call('ldp.resource.delete', {
+            resourceUri: accessGrantUri,
+            webId
+          });
+        }
+      }
+    }
   }
 };

--- a/packages/app/services/app-registrations.js
+++ b/packages/app/services/app-registrations.js
@@ -1,0 +1,11 @@
+const { ControlledContainerMixin } = require('@semapps/ldp');
+
+module.exports = {
+  name: 'app-registrations',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    path: '/app-registrations',
+    acceptedTypes: ['interop:ApplicationRegistration'],
+    newResourcesPermissions: {}
+  }
+};

--- a/packages/app/services/data-grants.js
+++ b/packages/app/services/data-grants.js
@@ -1,11 +1,11 @@
 const { ControlledContainerMixin } = require('@semapps/ldp');
 
 module.exports = {
-  name: 'access-needs',
+  name: 'data-grants',
   mixins: [ControlledContainerMixin],
   settings: {
-    path: '/access-needs',
-    acceptedTypes: ['interop:AccessNeed'],
-    readOnly: true
+    path: '/data-grants',
+    acceptedTypes: ['interop:DataGrant'],
+    newResourcesPermissions: {}
   }
 };

--- a/packages/app/services/registration.js
+++ b/packages/app/services/registration.js
@@ -1,42 +1,11 @@
 const { ActivitiesHandlerMixin, ACTIVITY_TYPES } = require('@semapps/activitypub');
-const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
+const { arrayOf } = require('@semapps/ldp');
 const { MIME_TYPES } = require('@semapps/mime-types');
 const { interopContext } = require('@semapps/core');
 
 module.exports = {
   name: 'app.installation',
   mixins: [ActivitiesHandlerMixin],
-  created() {
-    this.broker.createService({
-      name: 'application-registrations',
-      mixins: [ControlledContainerMixin],
-      settings: {
-        path: '/application-registrations',
-        acceptedTypes: ['interop:ApplicationRegistration'],
-        newResourcesPermissions: {}
-      }
-    });
-
-    this.broker.createService({
-      name: 'access-grants',
-      mixins: [ControlledContainerMixin],
-      settings: {
-        path: '/access-grants',
-        acceptedTypes: ['interop:AccessGrant'],
-        newResourcesPermissions: {}
-      }
-    });
-
-    this.broker.createService({
-      name: 'data-grants',
-      mixins: [ControlledContainerMixin],
-      settings: {
-        path: '/data-grants',
-        acceptedTypes: ['interop:DataGrant'],
-        newResourcesPermissions: {}
-      }
-    });
-  },
   activities: {
     createAppRegistration: {
       match: {
@@ -46,79 +15,88 @@ module.exports = {
         }
       },
       async onReceive(ctx, activity, recipientUri) {
-        // GET APP REGISTRATION AND GRANTS
-
-        const appRegistration = await ctx.call('ldp.remote.get', {
-          resourceUri: activity.object.id,
-          jsonContext: interopContext
-        });
-
-        const accessGrants = await Promise.all(
-          appRegistration['interop:hasAccessGrant'].map(accessGrantUri =>
-            ctx.call('ldp.remote.get', {
-              resourceUri: accessGrantUri,
-              jsonContext: interopContext,
-              accept: MIME_TYPES.JSON
-            })
-          )
-        );
-
-        const dataGrantsUris = accessGrants.reduce(
-          (acc, cur) => (cur['interop:hasDataGrant'] ? [...acc, cur['interop:hasDataGrant']] : acc),
-          []
-        );
-        const specialRightsUris = accessGrants.reduce(
-          (acc, cur) => (cur['apods:hasSpecialRights'] ? [...acc, cur['apods:hasSpecialRights']] : acc),
-          []
-        );
-
-        const dataGrants = await Promise.all(
-          dataGrantsUris.map(dataGrantUri =>
-            ctx.call('ldp.remote.get', {
-              resourceUri: dataGrantUri,
-              jsonContext: interopContext,
-              accept: MIME_TYPES.JSON
-            })
-          )
-        );
-
-        // CHECK THAT GRANTS MATCH WITH ACCESS NEEDS
-
-        const filteredContainer = await ctx.call('access-needs-groups.list', {
-          filters: {
-            'http://www.w3.org/ns/solid/interop#accessNecessity': 'http://www.w3.org/ns/solid/interop#AccessRequired'
-          },
-          accept: MIME_TYPES.JSON
-        });
-
-        const requiredAccessNeedGroup = filteredContainer['ldp:contains'];
-
-        // Return true if all access needs and special rights of the required AccessNeedGroup are granted
-        const accessNeedsSatisfied = arrayOf(requiredAccessNeedGroup).every(
-          group =>
-            arrayOf(group['interop:hasAccessNeed']).every(accessNeedUri =>
-              dataGrants.some(dataGrant => dataGrant['interop:satisfiesAccessNeed'] === accessNeedUri)
-            ) &&
-            arrayOf(group['interop:hasSpecialRights']).every(specialRightUri =>
-              specialRightsUris.some(sr => sr === specialRightUri)
-            )
-        );
-
-        // SEND BACK RESULT
-
         const outboxUri = await ctx.call('activitypub.actor.getCollectionUri', {
           actorUri: recipientUri,
           predicate: 'outbox'
         });
 
-        if (!accessNeedsSatisfied) {
-          await ctx.call('activitypub.outbox.post', {
-            collectionUri: outboxUri,
-            type: ACTIVITY_TYPES.REJECT,
-            object: activity.id,
-            to: activity.actor
+        try {
+          // ENSURE THE APP IS NOT ALREADY REGISTERED
+
+          let filteredContainer = await ctx.call('app-registrations.list', {
+            filters: {
+              'http://www.w3.org/ns/solid/interop#registeredBy': activity.actor
+            },
+            accept: MIME_TYPES.JSON
           });
-        } else {
+
+          if (filteredContainer.length > 0) {
+            throw new Error(`User ${recipientUri} already has an application registration. Update or delete it.`);
+          }
+
+          // GET APP REGISTRATION AND GRANTS
+
+          const appRegistration = await ctx.call('ldp.remote.get', {
+            resourceUri: activity.object.id,
+            jsonContext: interopContext
+          });
+
+          const accessGrants = await Promise.all(
+            appRegistration['interop:hasAccessGrant'].map(accessGrantUri =>
+              ctx.call('ldp.remote.get', {
+                resourceUri: accessGrantUri,
+                jsonContext: interopContext,
+                accept: MIME_TYPES.JSON
+              })
+            )
+          );
+
+          const dataGrantsUris = accessGrants.reduce(
+            (acc, cur) => (cur['interop:hasDataGrant'] ? [...acc, cur['interop:hasDataGrant']] : acc),
+            []
+          );
+          const specialRightsUris = accessGrants.reduce(
+            (acc, cur) => (cur['apods:hasSpecialRights'] ? [...acc, cur['apods:hasSpecialRights']] : acc),
+            []
+          );
+
+          const dataGrants = await Promise.all(
+            dataGrantsUris.map(dataGrantUri =>
+              ctx.call('ldp.remote.get', {
+                resourceUri: dataGrantUri,
+                jsonContext: interopContext,
+                accept: MIME_TYPES.JSON
+              })
+            )
+          );
+
+          // CHECK THAT GRANTS MATCH WITH ACCESS NEEDS
+
+          filteredContainer = await ctx.call('access-needs-groups.list', {
+            filters: {
+              'http://www.w3.org/ns/solid/interop#accessNecessity': 'http://www.w3.org/ns/solid/interop#AccessRequired'
+            },
+            accept: MIME_TYPES.JSON
+          });
+
+          const requiredAccessNeedGroups = arrayOf(filteredContainer['ldp:contains']);
+
+          // Return true if all access needs and special rights of the required AccessNeedGroups are granted
+          const accessNeedsSatisfied = requiredAccessNeedGroups.every(
+            group =>
+              arrayOf(group['interop:hasAccessNeed']).every(accessNeedUri =>
+                dataGrants.some(dataGrant => dataGrant['interop:satisfiesAccessNeed'] === accessNeedUri)
+              ) &&
+              arrayOf(group['interop:hasSpecialRights']).every(specialRightUri =>
+                specialRightsUris.some(sr => sr === specialRightUri)
+              )
+          );
+
+          if (!accessNeedsSatisfied) {
+            throw new Error('One or more required access needs have not been granted');
+          }
+
+          // SEND BACK RESULT
           await ctx.call('activitypub.outbox.post', {
             collectionUri: outboxUri,
             type: ACTIVITY_TYPES.ACCEPT,
@@ -137,6 +115,14 @@ module.exports = {
           for (const dataGrant of dataGrants) {
             await ctx.call('ldp.remote.store', { resource: dataGrant });
           }
+        } catch (e) {
+          await ctx.call('activitypub.outbox.post', {
+            collectionUri: outboxUri,
+            type: ACTIVITY_TYPES.REJECT,
+            summary: e.message,
+            object: activity.id,
+            to: activity.actor
+          });
         }
       }
     }

--- a/packages/core/config/context-interop.json
+++ b/packages/core/config/context-interop.json
@@ -2,6 +2,7 @@
   "interop": "http://www.w3.org/ns/solid/interop#",
   "acl": "http://www.w3.org/ns/auth/acl#",
   "apods": "http://activitypods.org/ns/core#",
+  "ldp": "http://www.w3.org/ns/ldp#",
   "interop:accessNecessity": {
     "@type": "@id"
   },

--- a/packages/core/config/context-interop.json
+++ b/packages/core/config/context-interop.json
@@ -3,6 +3,8 @@
   "acl": "http://www.w3.org/ns/auth/acl#",
   "apods": "http://activitypods.org/ns/core#",
   "ldp": "http://www.w3.org/ns/ldp#",
+  "dc": "http://purl.org/dc/terms/",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
   "interop:accessNecessity": {
     "@type": "@id"
   },

--- a/packages/core/services/installation/sub-services/access-grants.js
+++ b/packages/core/services/installation/sub-services/access-grants.js
@@ -1,0 +1,15 @@
+const { ControlledContainerMixin } = require('@semapps/ldp');
+
+module.exports = {
+  name: 'access-grants',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    path: '/access-grants',
+    acceptedTypes: ['interop:AccessGrant'],
+    newResourcesPermissions: {
+      anon: {
+        read: true
+      }
+    }
+  }
+};

--- a/packages/core/services/installation/sub-services/access-grants.js
+++ b/packages/core/services/installation/sub-services/access-grants.js
@@ -10,6 +10,7 @@ module.exports = {
       anon: {
         read: true
       }
-    }
+    },
+    excludeFromMirror: true
   }
 };

--- a/packages/core/services/installation/sub-services/app-registrations.js
+++ b/packages/core/services/installation/sub-services/app-registrations.js
@@ -1,0 +1,73 @@
+const { ControlledContainerMixin, arrayOf } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const interopContext = require('../../../config/context-interop.json');
+
+module.exports = {
+  name: 'app-registrations',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    path: '/app-registrations',
+    acceptedTypes: ['interop:ApplicationRegistration'],
+    newResourcesPermissions: {
+      anon: {
+        read: true
+      }
+    }
+  },
+  actions: {
+    async getForApp(ctx) {
+      const { appUri } = ctx.params;
+
+      let filteredContainer = await this.actions.list(
+        {
+          filters: {
+            'http://www.w3.org/ns/solid/interop#registeredAgent': appUri
+          },
+          jsonContext: interopContext,
+          accept: MIME_TYPES.JSON,
+          webId: 'system'
+        },
+        { parentCtx: ctx }
+      );
+
+      return filteredContainer['ldp:contains']?.[0];
+    }
+  },
+  hooks: {
+    before: {
+      async delete(ctx) {
+        const { resourceUri, webId } = ctx.params;
+
+        const appRegistration = await ctx.call('ldp.resource.get', {
+          resourceUri,
+          jsonContext: interopContext,
+          accept: MIME_TYPES.JSON,
+          webId
+        });
+
+        // DELETE ALL RELATED GRANTS
+
+        for (const accessGrantUri of arrayOf(appRegistration['interop:hasAccessGrant'])) {
+          const accessGrant = await ctx.call('ldp.resource.get', {
+            resourceUri: accessGrantUri,
+            jsonContext: interopContext,
+            accept: MIME_TYPES.JSON,
+            webId
+          });
+
+          for (const dataGrantUri of arrayOf(accessGrant['interop:hasDataGrant'])) {
+            await ctx.call('ldp.resource.delete', {
+              resourceUri: dataGrantUri,
+              webId
+            });
+          }
+
+          await ctx.call('ldp.resource.delete', {
+            resourceUri: accessGrantUri,
+            webId
+          });
+        }
+      }
+    }
+  }
+};

--- a/packages/core/services/installation/sub-services/app-registrations.js
+++ b/packages/core/services/installation/sub-services/app-registrations.js
@@ -12,7 +12,8 @@ module.exports = {
       anon: {
         read: true
       }
-    }
+    },
+    excludeFromMirror: true
   },
   actions: {
     async getForApp(ctx) {
@@ -24,8 +25,7 @@ module.exports = {
             'http://www.w3.org/ns/solid/interop#registeredAgent': appUri
           },
           jsonContext: interopContext,
-          accept: MIME_TYPES.JSON,
-          webId: 'system'
+          accept: MIME_TYPES.JSON
         },
         { parentCtx: ctx }
       );

--- a/packages/core/services/installation/sub-services/data-grants.js
+++ b/packages/core/services/installation/sub-services/data-grants.js
@@ -10,6 +10,7 @@ module.exports = {
       anon: {
         read: true
       }
-    }
+    },
+    excludeFromMirror: true
   }
 };

--- a/packages/core/services/installation/sub-services/data-grants.js
+++ b/packages/core/services/installation/sub-services/data-grants.js
@@ -1,0 +1,15 @@
+const { ControlledContainerMixin } = require('@semapps/ldp');
+
+module.exports = {
+  name: 'data-grants',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    path: '/data-grants',
+    acceptedTypes: ['interop:DataGrant'],
+    newResourcesPermissions: {
+      anon: {
+        read: true
+      }
+    }
+  }
+};

--- a/tests/apps/example.app.js
+++ b/tests/apps/example.app.js
@@ -4,8 +4,10 @@ const { AS_PREFIX } = require('@semapps/activitypub');
 module.exports = {
   mixins: [AppService],
   settings: {
-    name: 'Example App',
-    description: 'An ActivityPods app for integration tests',
+    app: {
+      name: 'Example App',
+      description: 'An ActivityPods app for integration tests'
+    },
     accessNeeds: {
       required: [
         {


### PR DESCRIPTION
Close #101 

- Prevent to install app if it is already installed
- Handle `Undo > apods:Install` activities sent to the outbox
  - On uninstall, delete app registration (and associated grants) 
  - Warn app with a `Delete > interop:ApplicationRegistration` activity
  - On reception, app delete the cached app registration (and associated grants)
- Refactor existing code
- Add new tests