### PR TITLE
Chore: remove deprecated lerna bootstrap commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ docker-compose up -d fuseki
 
 ```
 yarn install
-yarn run bootstrap
 cd backend
 yarn run dev
 ```
@@ -198,7 +197,6 @@ Follow the guide [here](deploy/README.md).
 
 ```
 yarn install
-yarn run bootstrap
 docker-compose up -d fuseki_test
 cd tests
 yarn run test

--- a/deploy/backend/Dockerfile
+++ b/deploy/backend/Dockerfile
@@ -21,7 +21,6 @@ RUN git clone https://github.com/assemblee-virtuelle/activitypods.git /activityp
 ADD app /activitypods/backend
 
 RUN yarn install
-RUN yarn run bootstrap
 
 WORKDIR /activitypods/backend
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap",
     "version": "lerna version --force-publish='*' --exact",
     "publish": "lerna publish from-package --dist-tag latest",
     "prettier": "prettier --write '**/*.js'",


### PR DESCRIPTION
The functionaliy is now handled by `yarn` or `yarn install`.