### PR TITLE
Basic TypeIndex implementation

### DIFF
--- a/packages/app/service.js
+++ b/packages/app/service.js
@@ -14,6 +14,7 @@ const DataGrantsService = require('./services/registration/data-grants');
 const RegistrationService = require('./services/registration/registration');
 const PodActivitiesWatcherService = require('./services/pod-handling/pod-activities-watcher');
 const PodCollectionsService = require('./services/pod-handling/pod-collections');
+const PodContainersService = require('./services/pod-handling/pod-containers');
 const PodNotificationService = require('./services/pod-handling/pod-notification');
 const PodOutboxService = require('./services/pod-handling/pod-outbox');
 const PodPermissionsService = require('./services/pod-handling/pod-permissions');
@@ -87,6 +88,7 @@ module.exports = {
       }
     });
     this.broker.createService(PodCollectionsService);
+    this.broker.createService(PodContainersService);
     this.broker.createService(PodOutboxService);
     this.broker.createService(PodPermissionsService);
     this.broker.createService(PodResourcesService);

--- a/packages/app/services/pod-handling/pod-containers.js
+++ b/packages/app/services/pod-handling/pod-containers.js
@@ -1,0 +1,152 @@
+const SparqlGenerator = require('sparqljs').Generator;
+const { triple, namedNode } = require('@rdfjs/data-model');
+const { arrayOf } = require('@semapps/ldp');
+const FetchPodOrProxyMixin = require('../../mixins/fetch-pod-or-proxy');
+
+module.exports = {
+  name: 'pod-containers',
+  mixins: [FetchPodOrProxyMixin],
+  started() {
+    this.sparqlGenerator = new SparqlGenerator({
+      /* prefixes, baseIRI, factory, sparqlStar */
+    });
+  },
+  actions: {
+    /**
+     * Fetch the TypeIndex and return the first containerUri that holds resources of the given type
+     * TODO Use some cache mechanism, or fetch all type registration at the app start
+     */
+    getByType: {
+      params: {
+        type: { type: 'string', optional: false },
+        actorUri: { type: 'string', optional: false }
+      },
+      async handler(ctx) {
+        const { type } = ctx.params;
+
+        const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+
+        const { body: actor } = await this.actions.fetch({
+          url: actorUri,
+          headers: {
+            'Content-Type': 'application/ld+json'
+          },
+          actorUri
+        });
+
+        if (actor['solid:publicTypeIndex']) {
+          const { body: typeIndex } = await this.actions.fetch({
+            url: actor['solid:publicTypeIndex'],
+            headers: {
+              'Content-Type': 'application/ld+json'
+            },
+            actorUri
+          });
+
+          // Go through all TypeRegistration
+          for (const registrationUri of arrayOf(typeIndex['solid:hasTypeRegistration'])) {
+            const { body: registration } = await this.actions.fetch({
+              url: registrationUri,
+              headers: {
+                'Content-Type': 'application/ld+json'
+              },
+              actorUri
+            });
+
+            const expandedRegisteredTypes = await ctx.call('jsonld.parser.expandTypes', {
+              types: registration['solid:forClass']
+            });
+
+            if (expandedRegisteredTypes.includes(expandedType)) {
+              return registration['solid:instanceContainer'];
+            }
+          }
+
+          throw new Error(`No container found for type ${expandedType} in the TypeIndex of ${actorUri}`);
+        }
+      }
+    },
+    attach: {
+      params: {
+        containerUri: { type: 'string', optional: false },
+        resourceUri: { type: 'string', optional: false },
+        actorUri: { type: 'string', optional: false }
+      },
+      async handler(ctx) {
+        const { containerUri, resourceUri, actorUri } = ctx.params;
+
+        const sparqlUpdate = {
+          type: 'update',
+          updates: [
+            {
+              updateType: 'insert',
+              insert: [
+                {
+                  type: 'bgp',
+                  triples: [
+                    triple(
+                      namedNode(containerUri),
+                      namedNode('http://www.w3.org/ns/ldp#contains'),
+                      namedNode(resourceUri)
+                    )
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+
+        await this.actions.fetch({
+          url: containerUri,
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/sparql-update'
+          },
+          body: this.sparqlGenerator.stringify(sparqlUpdate),
+          actorUri
+        });
+      }
+    },
+    detach: {
+      params: {
+        containerUri: { type: 'string', optional: false },
+        resourceUri: { type: 'string', optional: false },
+        actorUri: { type: 'string', optional: false }
+      },
+      async handler(ctx) {
+        const { containerUri, resourceUri, actorUri } = ctx.params;
+
+        const sparqlUpdate = {
+          type: 'update',
+          updates: [
+            {
+              updateType: 'delete',
+              insert: [
+                {
+                  type: 'bgp',
+                  triples: [
+                    triple(
+                      namedNode(containerUri),
+                      namedNode('http://www.w3.org/ns/ldp#contains'),
+                      namedNode(resourceUri)
+                    )
+                  ]
+                }
+              ]
+            }
+          ]
+        };
+
+        await this.actions.fetch({
+          url: containerUri,
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/sparql-update'
+          },
+          body: this.sparqlGenerator.stringify(sparqlUpdate),
+          actorUri
+        });
+      }
+    }
+  }
+};

--- a/packages/app/services/pod-handling/pod-notification.js
+++ b/packages/app/services/pod-handling/pod-notification.js
@@ -19,7 +19,7 @@ module.exports = {
         let emitterProfile = {};
         try {
           emitterProfile = emitter.url
-            ? await ctx.call('pod-resources.get', { resourceUri: emitter.url, actorUri: recipientUri })
+            ? await ctx.call('pod-resources.get', { resourceUri: emitter.url, actorUri: activity.actor })
             : {};
         } catch (e) {
           this.logger.warn(`Could not get profile of actor ${activity.actor}`);

--- a/packages/app/services/pod-handling/pod-resources.js
+++ b/packages/app/services/pod-handling/pod-resources.js
@@ -1,4 +1,3 @@
-const { triple, namedNode } = require('@rdfjs/data-model');
 const FetchPodOrProxyMixin = require('../../mixins/fetch-pod-or-proxy');
 const SparqlGenerator = require('sparqljs').Generator;
 
@@ -161,88 +160,6 @@ module.exports = {
         await this.actions.fetch({
           url: resourceUri,
           method: 'DELETE',
-          actorUri
-        });
-      }
-    },
-    attach: {
-      params: {
-        containerUri: { type: 'string', optional: false },
-        resourceUri: { type: 'string', optional: false },
-        actorUri: { type: 'string', optional: false }
-      },
-      async handler(ctx) {
-        const { containerUri, resourceUri, actorUri } = ctx.params;
-
-        const sparqlUpdate = {
-          type: 'update',
-          updates: [
-            {
-              updateType: 'insert',
-              insert: [
-                {
-                  type: 'bgp',
-                  triples: [
-                    triple(
-                      namedNode(containerUri),
-                      namedNode('http://www.w3.org/ns/ldp#contains'),
-                      namedNode(resourceUri)
-                    )
-                  ]
-                }
-              ]
-            }
-          ]
-        };
-
-        await this.actions.fetch({
-          url: containerUri,
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/sparql-update'
-          },
-          body: this.sparqlGenerator.stringify(sparqlUpdate),
-          actorUri
-        });
-      }
-    },
-    detach: {
-      params: {
-        containerUri: { type: 'string', optional: false },
-        resourceUri: { type: 'string', optional: false },
-        actorUri: { type: 'string', optional: false }
-      },
-      async handler(ctx) {
-        const { containerUri, resourceUri, actorUri } = ctx.params;
-
-        const sparqlUpdate = {
-          type: 'update',
-          updates: [
-            {
-              updateType: 'delete',
-              insert: [
-                {
-                  type: 'bgp',
-                  triples: [
-                    triple(
-                      namedNode(containerUri),
-                      namedNode('http://www.w3.org/ns/ldp#contains'),
-                      namedNode(resourceUri)
-                    )
-                  ]
-                }
-              ]
-            }
-          ]
-        };
-
-        await this.actions.fetch({
-          url: containerUri,
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/sparql-update'
-          },
-          body: this.sparqlGenerator.stringify(sparqlUpdate),
           actorUri
         });
       }

--- a/packages/core/service.js
+++ b/packages/core/service.js
@@ -17,7 +17,8 @@ const { WebfingerService } = require('@semapps/webfinger');
 const { WebIdService } = require('@semapps/webid');
 const { AnnouncerService } = require('@activitypods/announcer');
 const { NotificationProviderService } = require('@activitypods/solid-notifications');
-const { apods, interop, notify, oidc } = require('@activitypods/ontologies');
+const { TypeIndexesService } = require('@activitypods/type-index');
+const { apods, interop, notify, oidc, solid } = require('@activitypods/ontologies');
 const { ManagementService } = require('./services/management');
 const ApiService = require('./services/api');
 const AppOpenerService = require('./services/app-opener');
@@ -120,7 +121,7 @@ const CoreService = {
 
     this.broker.createService(OntologiesService, {
       settings: {
-        ontologies: [apods, interop, notify, oidc, dc, syreen, mp, pair, voidOntology],
+        ontologies: [apods, interop, notify, oidc, solid, dc, syreen, mp, pair, voidOntology],
         persistRegistry: false,
         settingsDataset
       }
@@ -248,6 +249,8 @@ const CoreService = {
         queueServiceUrl
       }
     });
+
+    this.broker.createService({ mixins: [TypeIndexesService] });
 
     this.broker.createService(MailNotificationsService, {
       mixins: queueServiceUrl ? [QueueService(queueServiceUrl)] : undefined,

--- a/packages/core/services/installation/sub-services/data-grants.js
+++ b/packages/core/services/installation/sub-services/data-grants.js
@@ -81,8 +81,8 @@ module.exports = {
         // If no container exist yet, create it and register it in the TypeIndex
         if (containersUris.length === 0) {
           // Generate a path for the new container
-          const containerPath = await ctx.call('ldp.container.getPath', { resourceType: expandedType });
-          this.logger.debug(`Automatically generated the path ${path} for resource type ${expandedType}`);
+          const containerPath = await ctx.call('ldp.container.getPath', { resourceType });
+          this.logger.debug(`Automatically generated the path ${containerPath} for resource type ${resourceType}`);
 
           // Create the container and attach it to its parent(s)
           containersUris[0] = urlJoin(webId, 'data', containerPath);

--- a/packages/core/services/mail-notifications.js
+++ b/packages/core/services/mail-notifications.js
@@ -73,10 +73,11 @@ module.exports = {
         type: 'apods:Notification'
       },
       async onReceive(ctx, activity, recipientUri) {
-        if (!(await ctx.call('app-registrations.isRegistered', { appUri: activity.actor, podOwner: recipientUri }))) {
-          this.logger.warn(`Application ${activity.actor} is not registered by ${recipientUri}`);
-          return;
-        }
+        // TODO Allow to user to disable notifications from given applications
+        // if (!(await ctx.call('app-registrations.isRegistered', { appUri: activity.actor, podOwner: recipientUri }))) {
+        //   this.logger.warn(`Application ${activity.actor} is not registered by ${recipientUri}`);
+        //   return;
+        // }
 
         const account = await ctx.call('auth.account.findByWebId', { webId: recipientUri });
 

--- a/packages/ontologies/index.js
+++ b/packages/ontologies/index.js
@@ -2,5 +2,6 @@ module.exports = {
   apods: require('./apods.json'),
   interop: require('./interop.json'),
   notify: require('./notify.json'),
-  oidc: require('./oidc.json')
+  oidc: require('./oidc.json'),
+  solid: require('./solid.json')
 };

--- a/packages/ontologies/solid.json
+++ b/packages/ontologies/solid.json
@@ -1,0 +1,24 @@
+{
+  "prefix": "solid",
+  "namespace": "http://www.w3.org/ns/solid/terms#",
+  "jsonldContext": {
+    "solid:publicTypeIndex": {
+      "@type": "@id"
+    },
+    "solid:privateTypeIndex": {
+      "@type": "@id"
+    },
+    "solid:hasTypeRegistration": {
+      "@type": "@id"
+    },
+    "solid:forClass": {
+      "@type": "@id"
+    },
+    "solid:instance": {
+      "@type": "@id"
+    },
+    "solid:instanceContainer": {
+      "@type": "@id"
+    }
+  }
+}

--- a/packages/solid-notifications/services/provider/sub-services/webhook.js
+++ b/packages/solid-notifications/services/provider/sub-services/webhook.js
@@ -58,6 +58,10 @@ module.exports = {
     // Load all channels from all Pods
     for (const dataset of await this.broker.call('pod.list')) {
       const webId = urlJoin(this.settings.baseUrl, dataset);
+
+      const containerUri = await this.actions.getContainerUri({ webId });
+      await this.actions.waitForContainerCreation({ containerUri });
+
       const container = await this.actions.list({ webId });
       for (const channel of arrayOf(container['ldp:contains'])) {
         this.channels.push({

--- a/packages/type-index/LICENSE
+++ b/packages/type-index/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/type-index/index.js
+++ b/packages/type-index/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  TypeIndexesService: require('./services/type-indexes')
+};

--- a/packages/type-index/package.json
+++ b/packages/type-index/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@rdfjs/data-model": "^1.3.4",
-    "@semapps/ldp": "0.8.0"
+    "@semapps/ldp": "0.8.0",
+    "@semapps/mime-types": "0.8.0",
+    "url-join": "^4.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/type-index/package.json
+++ b/packages/type-index/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activitypods/type-index",
+  "version": "2.0.0-alpha.0",
+  "description": "ActivityPods package for Solid TypeIndex",
+  "license": "Apache-2.0",
+  "author": "Virtual Assembly",
+  "homepage": "https://activitypods.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/assemblee-virtuelle/activitypods.git",
+    "directory": "packages/type-index"
+  },
+  "dependencies": {
+    "@rdfjs/data-model": "^1.3.4",
+    "@semapps/ldp": "0.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/type-index/services/type-indexes.js
+++ b/packages/type-index/services/type-indexes.js
@@ -1,0 +1,64 @@
+const { ControlledContainerMixin, getDatasetFromUri } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
+const { namedNode, triple } = require('@rdfjs/data-model');
+const TypeRegistrationsService = require('./type-registrations');
+
+module.exports = {
+  name: 'type-indexes',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    acceptedTypes: ['solid:TypeIndex']
+  },
+  create() {
+    this.broker.createService({
+      mixins: [TypeRegistrationsService]
+    });
+  },
+  actions: {
+    async createAndAttachToWebId(ctx) {
+      const { webId } = ctx.params;
+
+      const indexUri = await this.actions.post(
+        {
+          resource: {
+            type: ['solid:TypeIndex', 'solid:ListedDocument']
+          },
+          webId
+        },
+        { parentCtx: ctx }
+      );
+
+      await ctx.call('ldp.resource.patch', {
+        resourceUri: webId,
+        triplesToAdd: [
+          triple(namedNode(webId), namedNode('http://www.w3.org/ns/solid/terms#publicTypeIndex'), namedNode(indexUri))
+        ],
+        webId
+      });
+    },
+    async findByWebId(ctx) {
+      const { webId } = ctx.params;
+
+      const user = await ctx.call('ldp.resource.get', {
+        resourceUri: webId,
+        accept: MIME_TYPES.JSON,
+        webId
+      });
+
+      return user['solid:publicTypeIndex'];
+    },
+    async migrate(ctx) {
+      const accounts = await ctx.call('auth.account.find');
+      for (const { webId } of accounts) {
+        this.logger.info(`Migrating ${webId}...`);
+        await this.actions.createAndAttachToWebId({ webId }, { parentCtx: ctx });
+      }
+    }
+  },
+  events: {
+    async 'auth.registered'(ctx) {
+      const { webId } = ctx.params;
+      await this.actions.createAndAttachToWebId({ webId }, { parentCtx: ctx });
+    }
+  }
+};

--- a/packages/type-index/services/type-registrations.js
+++ b/packages/type-index/services/type-registrations.js
@@ -1,86 +1,206 @@
 const urlJoin = require('url-join');
-const { ControlledContainerMixin } = require('@semapps/ldp');
+const { namedNode, triple } = require('@rdfjs/data-model');
+const { ControlledContainerMixin, arrayOf, getDatasetFromUri } = require('@semapps/ldp');
+const { MIME_TYPES } = require('@semapps/mime-types');
 
 module.exports = {
   name: 'type-registrations',
   mixins: [ControlledContainerMixin],
   settings: {
-    acceptedTypes: ['solid:TypeRegistration']
+    acceptedTypes: ['solid:TypeRegistration'],
+    permissions: {
+      default: {
+        anon: {
+          read: true
+        }
+      }
+    },
+    excludeFromMirror: true
   },
   actions: {
-    async register(ctx) {
-      const { webId, type } = ctx.params;
+    register: {
+      visibility: 'public',
+      params: {
+        type: { type: 'string' },
+        containerUri: { type: 'string' },
+        webId: { type: 'string' }
+      },
+      async handler(ctx) {
+        let { type, containerUri, webId } = ctx.params;
 
-      const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+        const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
 
-      // Check if a container was already registered with this type
-      let containerUri = await this.actions.findContainerUri({ webId, type: expandedType });
+        // Check if the container was already registered
+        let existingRegistration = await this.actions.getByContainerUri({ containerUri, webId });
 
-      if (!containerUri) {
-        // Generate a path for the new container
-        const containerPath = await ctx.call('ldp.container.getPath', { resourceType: expandedType });
-        this.logger.debug(`Automatically generated the path ${path} for resource type ${expandedType}`);
+        if (existingRegistration) {
+          const expandedRegisteredTypes = await ctx.call('jsonld.parser.expandTypes', {
+            types: existingRegistration['solid:forClass']
+          });
 
-        // Create the container and attach it to its parent(s)
-        containerUri = urlJoin(webId, 'data', containerPath);
-        await ctx.call('ldp.container.createAndAttach', { containerUri, webId });
+          // If the container is registered with other types, append the new type
+          if (!expandedRegisteredTypes.includes(expandedType)) {
+            await this.actions.patch({
+              resourceUri: existingRegistration.id,
+              triplesToAdd: [
+                triple(
+                  namedNode(existingRegistration.id),
+                  namedNode('http://www.w3.org/ns/solid/terms#forClass'),
+                  namedNode(expandedType)
+                )
+              ],
+              webId
+            });
+          }
 
-        // Find the Type Index linked with the WebId
-        const indexUri = await ctx.call('type-indexes.findByWebId', { webId });
-        if (!indexUri) throw new Error(`No public type index associated with webId ${webId}`);
+          return existingRegistration;
+        } else {
+          // Ensure there is no registration for this type on another container
+          // existingRegistration = await this.actions.getByType({ type: expandedType, webId });
 
-        // Create the type registration
-        const registrationUri = await this.actions.post(
-          {
-            resource: {
-              type: 'solid:TypeRegistration',
-              'solid:forClass': expandedType,
-              'solid:instanceContainer': containerUri
+          // if (existingRegistration && existingRegistration['solid:instanceContainer'] !== containerUri) {
+          //   throw new Error(
+          //     `Cannot register ${containerUri} for type ${type} because the container ${existingRegistration['solid:instanceContainer']} is already registered for this type.`
+          //   );
+          // }
+
+          // Find the TypeIndex linked with the WebId
+          const indexUri = await ctx.call('type-indexes.findByWebId', { webId });
+          if (!indexUri) throw new Error(`No public type index associated with webId ${webId}`);
+
+          // Create the type registration
+          const registrationUri = await this.actions.post(
+            {
+              resource: {
+                type: 'solid:TypeRegistration',
+                'solid:forClass': expandedType,
+                'solid:instanceContainer': containerUri
+              },
+              contentType: MIME_TYPES.JSON,
+              webId
             },
+            { parentCtx: ctx }
+          );
+
+          // Attach it to the TypeIndex
+          await ctx.call('type-indexes.patch', {
+            resourceUri: indexUri,
+            triplesToAdd: [
+              triple(
+                namedNode(indexUri),
+                namedNode('http://www.w3.org/ns/solid/terms#hasTypeRegistration'),
+                namedNode(registrationUri)
+              )
+            ],
+            webId
+          });
+
+          return registrationUri;
+        }
+      }
+    },
+    getByType: {
+      visibility: 'public',
+      params: {
+        type: { type: 'string' },
+        webId: { type: 'string' }
+      },
+      async handler(ctx) {
+        const { type, webId } = ctx.params;
+
+        const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+
+        const filteredContainer = await this.actions.list(
+          {
+            filters: { 'http://www.w3.org/ns/solid/terms#forClass': expandedType },
             webId
           },
           { parentCtx: ctx }
         );
 
-        // Attach it to the Type Index
-        await ctx.call('ldp.resource.patch', {
-          resourceUri: indexUri,
-          triplesToAdd: [
-            triple(
-              namedNode(indexUri),
-              namedNode('http://www.w3.org/ns/solid/terms#hasTypeRegistration'),
-              namedNode(registrationUri)
-            )
-          ],
-          webId
-        });
+        // There can be several TypeRegistration per type
+        return arrayOf(filteredContainer['ldp:contains']);
       }
-
-      return containerUri;
     },
-    async findContainerUri(ctx) {
-      const { type, webId } = ctx.params;
+    getByContainerUri: {
+      visibility: 'public',
+      params: {
+        containerUri: { type: 'string' },
+        webId: { type: 'string' }
+      },
+      async handler(ctx) {
+        const { containerUri, webId } = ctx.params;
 
-      const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+        const filteredContainer = await this.actions.list(
+          {
+            filters: { 'http://www.w3.org/ns/solid/terms#instanceContainer': containerUri },
+            webId
+          },
+          { parentCtx: ctx }
+        );
 
-      const dataset = getDatasetFromUri(webId);
+        // There should be only one TypeRegistration per container
+        return arrayOf(filteredContainer['ldp:contains'])[0];
+      }
+    },
+    findContainersUris: {
+      visibility: 'public',
+      params: {
+        type: { type: 'string' },
+        webId: { type: 'string' }
+      },
+      async handler(ctx) {
+        const { type, webId } = ctx.params;
 
-      const results = await ctx.call('triplestore.query', {
-        query: `
-          PREFIX solid: <http://www.w3.org/ns/solid/terms#>
-          SELECT ?containerUri
-          WHERE {
-            ?registration a solid:TypeRegistration .
-            ?registration solid:forClass <${expandedType}> .
-            ?registration solid:instanceContainer ?containerUri .
+        const registrations = await this.actions.getByType({ type, webId });
+
+        return registrations.map(r => r['solid:instanceContainer']);
+      }
+    },
+    addMissing: {
+      visibility: 'public',
+      async handler(ctx) {
+        const accounts = await ctx.call('auth.account.find');
+        const registeredContainers = await ctx.call('ldp.registry.list');
+        // Go through each Pod
+        for (const { webId, podUri } of accounts) {
+          // Go through each registered container
+          for (const container of Object.values(registeredContainers)) {
+            if (container.podsContainer !== true) {
+              const containerUri = urlJoin(podUri, container.path);
+              for (const type of arrayOf(container.acceptedTypes)) {
+                await this.actions.register({ type, containerUri, webId }, { parentCtx: ctx });
+              }
+            }
           }
-        `,
-        accept: MIME_TYPES.JSON,
-        dataset,
-        webId
+        }
+      }
+    }
+  },
+  events: {
+    async 'auth.registered'(ctx) {
+      const { webId, accountData } = ctx.params;
+
+      // Wait until the /solid/type-registration container has been created for the user
+      const registrationsContainerUri = await this.actions.getContainerUri({ webId }, { parentCtx: ctx });
+      await this.actions.waitForContainerCreation({ containerUri: registrationsContainerUri }, { parentCtx: ctx });
+
+      // Wait until the public TypeIndex has been created
+      await ctx.call('ldp.resource.awaitCreateComplete', {
+        resourceUri: webId,
+        predicates: ['solid:publicTypeIndex']
       });
 
-      return results[0]?.containerUri.value;
+      const registeredContainers = await ctx.call('ldp.registry.list');
+
+      // Go through each registered container
+      for (const container of Object.values(registeredContainers)) {
+        if (container.podsContainer !== true) {
+          const containerUri = urlJoin(accountData.podUri, container.path);
+          for (const type of arrayOf(container.acceptedTypes))
+            await this.actions.register({ type, containerUri, webId }, { parentCtx: ctx });
+        }
+      }
     }
   }
 };

--- a/packages/type-index/services/type-registrations.js
+++ b/packages/type-index/services/type-registrations.js
@@ -1,0 +1,86 @@
+const urlJoin = require('url-join');
+const { ControlledContainerMixin } = require('@semapps/ldp');
+
+module.exports = {
+  name: 'type-registrations',
+  mixins: [ControlledContainerMixin],
+  settings: {
+    acceptedTypes: ['solid:TypeRegistration']
+  },
+  actions: {
+    async register(ctx) {
+      const { webId, type } = ctx.params;
+
+      const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+
+      // Check if a container was already registered with this type
+      let containerUri = await this.actions.findContainerUri({ webId, type: expandedType });
+
+      if (!containerUri) {
+        // Generate a path for the new container
+        const containerPath = await ctx.call('ldp.container.getPath', { resourceType: expandedType });
+        this.logger.debug(`Automatically generated the path ${path} for resource type ${expandedType}`);
+
+        // Create the container and attach it to its parent(s)
+        containerUri = urlJoin(webId, 'data', containerPath);
+        await ctx.call('ldp.container.createAndAttach', { containerUri, webId });
+
+        // Find the Type Index linked with the WebId
+        const indexUri = await ctx.call('type-indexes.findByWebId', { webId });
+        if (!indexUri) throw new Error(`No public type index associated with webId ${webId}`);
+
+        // Create the type registration
+        const registrationUri = await this.actions.post(
+          {
+            resource: {
+              type: 'solid:TypeRegistration',
+              'solid:forClass': expandedType,
+              'solid:instanceContainer': containerUri
+            },
+            webId
+          },
+          { parentCtx: ctx }
+        );
+
+        // Attach it to the Type Index
+        await ctx.call('ldp.resource.patch', {
+          resourceUri: indexUri,
+          triplesToAdd: [
+            triple(
+              namedNode(indexUri),
+              namedNode('http://www.w3.org/ns/solid/terms#hasTypeRegistration'),
+              namedNode(registrationUri)
+            )
+          ],
+          webId
+        });
+      }
+
+      return containerUri;
+    },
+    async findContainerUri(ctx) {
+      const { type, webId } = ctx.params;
+
+      const [expandedType] = await ctx.call('jsonld.parser.expandTypes', { types: [type] });
+
+      const dataset = getDatasetFromUri(webId);
+
+      const results = await ctx.call('triplestore.query', {
+        query: `
+          PREFIX solid: <http://www.w3.org/ns/solid/terms#>
+          SELECT ?containerUri
+          WHERE {
+            ?registration a solid:TypeRegistration .
+            ?registration solid:forClass <${expandedType}> .
+            ?registration solid:instanceContainer ?containerUri .
+          }
+        `,
+        accept: MIME_TYPES.JSON,
+        dataset,
+        webId
+      });
+
+      return results[0]?.containerUri.value;
+    }
+  }
+};

--- a/tests/pods-creation.test.js
+++ b/tests/pods-creation.test.js
@@ -108,6 +108,27 @@ describe('Test pods creation', mode => {
     });
   }, 80000);
 
+  test('Alice TypeIndex has been created', async () => {
+    const aliceData = await alice.call('ldp.resource.get', {
+      resourceUri: alice.id,
+      accept: MIME_TYPES.JSON
+    });
+
+    const typeIndexUri = aliceData['solid:publicTypeIndex'];
+
+    expect(typeIndexUri).not.toBeNull();
+
+    const typeIndex = await alice.call('ldp.resource.get', {
+      resourceUri: typeIndexUri,
+      accept: MIME_TYPES.JSON
+    });
+
+    expect(typeIndex).toMatchObject({
+      type: expect.arrayContaining(['solid:ListedDocument', 'solid:TypeIndex']),
+      'solid:hasTypeRegistration': expect.anything()
+    });
+  }, 80000);
+
   test('Alice can post on her Pod', async () => {
     projectUri = await alice.call('ldp.container.post', {
       containerUri: urlJoin(alice.id, 'data'),


### PR DESCRIPTION
> Requires https://github.com/assemblee-virtuelle/semapps/pull/1275

I started adapting the LdpRegistryService to handle the diversity of containers in Pods, but this is difficult to maintain, non-standard, and external apps don't have access to this in-memory information. Switching to TypeIndex solve many problems.

Notes:
- We will add a more complete TypeIndex support (also on the frontend) if we get the new NLnet grant submission.
- We have created a `pod-containers.getByType` action to find a container using TypeIndexes. It is not used at the moment.
- We have kept the `apods:registeredContainer` predicate in DataGrants since it is the fastest way for apps to find about containers
- Later we will probably create a @semapps/solid package with the notifications and type index features.

## Migration

Enter this command in Moleculer REPL:

```
call type-indexes.migrate
```

This will:
- Add types indexes in all Pods
- Link them from the WebID
- Add a TypeRegistration for all registered containers of all users

Additionnaly, if you add a ControlledContainer, you should call the `type-registrations.addMissing` action so that the TypeRegistration for the container is added on all existing pods.